### PR TITLE
Feature.ssorenso add jenkins smoketest

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -90,6 +90,13 @@ export SCENARIO_SESSION := scenario_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export DRIVER_TEMPEST_SESSION := driver.tempest_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 export FROM_AGENT_SESSION := from.agent_$(SUBJECTCODE_ID)_$(TIMESTAMP)
 
+# PR smoke testing...
+ifdef $(SMOKE_TEST)
+export TEST_RUN := run_smoke_tests
+else
+export TEST_RUN := run_tests
+endif
+
 # LEAF MAKE TARGETS:
 #
 # This section contains "leaf" make targets.  These targets do not call other
@@ -151,7 +158,7 @@ tempest_13.0.0_undercloud_vxlan:
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
+	$(MAKE) -C . ${TEST_RUN}
 
 # Tempest Tests for 12.1.1 undercloud VE deployment
 tempest_12.1.1_undercloud_vxlan:
@@ -163,7 +170,7 @@ tempest_12.1.1_undercloud_vxlan:
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
+	$(MAKE) -C . ${TEST_RUN}
 
 # Tempest Tests for 11.6.1 undercloud VE deployment
 tempest_11.6.1_undercloud_vxlan:
@@ -175,7 +182,7 @@ tempest_11.6.1_undercloud_vxlan:
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
+	$(MAKE) -C . ${TEST_RUN}
 
 # Tempest Tests for 11.5.4 undercloud VE deployment
 tempest_11.5.4_undercloud_vxlan:
@@ -187,7 +194,23 @@ tempest_11.5.4_undercloud_vxlan:
 	export TEST_SESSION=$@_$(SANITIZED_BRANCH)_$(SUBJECTCODE_ID)_$(TIMESTAMP) ;\
 	export TEST_TENANT_NETWORK_TYPE=vxlan ;\
 	export EXCLUDE_FILE=$@.yaml ;\
-	$(MAKE) -C . run_tests
+	$(MAKE) -C . ${TEST_RUN}
+
+smoke_test:
+	# change me  to stop PR tests!
+	export SMOKE_TEST=1
+	# make against the different versions we want to incorporate in smoke...
+	# see if we can't make some of this go into a parallel processing mode...
+	$(MAKE) -C . tempest_12.1.1_undercloud_vxlan & \
+	$(MAKE) -C . tempest_13.0.0_undercloud_vxlan & \
+	wait
+
+# Jenkins at-PR based run
+run_smoke_tests: install_tlc install_test_infra
+	$(MAKE) -C . setup_tlc_session
+	$(MAKE) -C . configure_test_infra
+	$(MAKE) -C . run_neutron_lbaas
+	$(MAKE) -C . cleanup_tlc_session
 
 run_tests: install_tlc install_test_infra
 	$(MAKE) -C . setup_tlc_session

--- a/systest/scripts/cleanup_tlc_session.sh
+++ b/systest/scripts/cleanup_tlc_session.sh
@@ -17,6 +17,12 @@
 
 set -x
 
+smoke_screen=""
+if [ ${SMOKE_TEST} == "1" ] && [ ${SMOKE_DEBUG} == "" ]; then
+    smoke_screen="> /dev/null"
+fi
+
 # Teardown the barbican worker and cleanup the TLC session
-tlc --session ${TEST_SESSION} --debug cmd uninstall_barbican
-tlc --session ${TEST_SESSION} --debug cleanup
+tlc --session ${TEST_SESSION} --debug cmd uninstall_barbican ${smoke_screen}
+tlc --session ${TEST_SESSION} --debug cleanup ${smoke_screen}
+

--- a/systest/scripts/run_neutron_lbaas.sh
+++ b/systest/scripts/run_neutron_lbaas.sh
@@ -27,19 +27,25 @@ cd ${NEUTRON_LBAAS_DIR}
 # Create .pytest.rootdir file at root of the neutron-lbaas repository directory
 touch ${NEUTRON_LBAAS_DIR}/.pytest.rootdir
 
+smoke_screen=""
+# Silent smoke tests for Jenkins PR instances
+if [ "$SMOKE_TESTS" == "1" ] && [ "$DEBUG_SMOKE" == "" ]; then
+    smoke_screen="> /dev/null"
+fi
+
 # LBaaSv2 API test cases with F5 tox.ini file
 tox -e apiv2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv --tb=short \
   --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${API_SESSION}
+  --autolog-session ${API_SESSION} ${smoke_screen}
 
 # LBaaSv2 Scenario test cases with F5 tox.ini file
 tox -e scenariov2 -c f5.tox.ini --sitepackages -- \
   --meta ${EXCLUDE_DIR}/${EXCLUDE_FILE} \
   -lvv --tb=short \
   --autolog-outputdir ${RESULTS_DIR} \
-  --autolog-session ${SCENARIO_SESSION}
+  --autolog-session ${SCENARIO_SESSION} ${smoke_screen}
 
 # Returning pass so that all tests run
 exit 0

--- a/systest/scripts/setup_tlc_session.sh
+++ b/systest/scripts/setup_tlc_session.sh
@@ -19,6 +19,11 @@ set -x
 
 set +e
 
+smoke_screen=""
+if [ ${SMOKE_TEST} == "1" ] && [ ${SMOKE_DEBUG} == "" ]; then
+    smoke_screen="> /dev/null"
+fi
+
 runTLCSetup() {
   # Excecute the TLC setup command given.
   eval $1
@@ -93,6 +98,6 @@ fi
 
 set -e
 # Run the remaining TLC commands
-/tools/bin/tlc --session ${TEST_SESSION} --debug cmd ready
-/tools/bin/tlc --session ${TEST_SESSION} --debug cmd test_env
-/tools/bin/tlc --session ${TEST_SESSION} --debug cmd lbaasv2
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd ready ${smoke_screen}
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd test_env ${smoke_screen}
+/tools/bin/tlc --session ${TEST_SESSION} --debug cmd lbaasv2 ${smoke_screen}


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes \#643 in main fork

#### What's this change do?
* Incorporates in the Makefile to incorporate smoke tests
* Has smoke tests simply run against 12.x.x. undercloud and 13.x.x undercloud for Liberty

#### Where should the reviewer start?
* Probably the make file paying attention to the SMOKE_TEST variable

#### Any background context?
* We spoke yesterday
